### PR TITLE
feat(chat): switch web chat to LM Studio HTTP tools

### DIFF
--- a/hindsight.sh
+++ b/hindsight.sh
@@ -174,28 +174,6 @@ cmd_start() {
         fi
     fi
 
-    # Start web dashboard
-    if is_web_running; then
-        echo -e "${YELLOW}Web dashboard is already running (PID: $(cat "$WEB_PID_FILE"))${NC}"
-    else
-        echo -n "  Starting web dashboard on port $WEB_PORT... "
-
-        # Start web server in background (using vite preview for production build)
-        nohup npm run preview --prefix "$SCRIPT_DIR/packages/web" >> "$WEB_LOG" 2>&1 &
-        local web_pid=$!
-        echo "$web_pid" > "$WEB_PID_FILE"
-
-        # Wait a moment and check if it started
-        sleep 2
-        if ps -p "$web_pid" > /dev/null 2>&1; then
-            echo -e "${GREEN}OK${NC} (PID: $web_pid)"
-        else
-            echo -e "${RED}FAILED${NC}"
-            echo "  Check logs: $WEB_LOG"
-            rm -f "$WEB_PID_FILE"
-        fi
-    fi
-
     # Start LM Studio plugin dev server
     if is_plugin_running; then
         echo -e "${YELLOW}Plugin dev server is already running (PID: $(cat "$PLUGIN_PID_FILE"))${NC}"
@@ -215,6 +193,28 @@ cmd_start() {
             echo -e "${RED}FAILED${NC}"
             echo "  Check logs: $PLUGIN_LOG"
             rm -f "$PLUGIN_PID_FILE"
+        fi
+    fi
+
+    # Start web dashboard
+    if is_web_running; then
+        echo -e "${YELLOW}Web dashboard is already running (PID: $(cat "$WEB_PID_FILE"))${NC}"
+    else
+        echo -n "  Starting web dashboard on port $WEB_PORT... "
+
+        # Start web server in background (using vite preview for production build)
+        nohup npm run preview --prefix "$SCRIPT_DIR/packages/web" >> "$WEB_LOG" 2>&1 &
+        local web_pid=$!
+        echo "$web_pid" > "$WEB_PID_FILE"
+
+        # Wait a moment and check if it started
+        sleep 2
+        if ps -p "$web_pid" > /dev/null 2>&1; then
+            echo -e "${GREEN}OK${NC} (PID: $web_pid)"
+        else
+            echo -e "${RED}FAILED${NC}"
+            echo "  Check logs: $WEB_LOG"
+            rm -f "$WEB_PID_FILE"
         fi
     fi
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -46,6 +46,13 @@ if (VERBOSE) {
   console.log('Verbose logging enabled - all requests will be logged');
 }
 
+// Runtime config for clients that need to mirror .env settings.
+app.get('/config', (_req, res) => {
+  res.json({
+    visionModel: process.env.VISION_MODEL || 'qwen/qwen3-vl-4b',
+  });
+});
+
 // Create ts-rest endpoints
 createExpressEndpoints(contract, router, app);
 
@@ -57,4 +64,5 @@ app.listen(PORT, () => {
   console.log(`  POST http://localhost:${PORT}/worklogs`);
   console.log(`  GET  http://localhost:${PORT}/worklogs?start=<timestamp>&end=<timestamp>`);
   console.log(`  GET  http://localhost:${PORT}/worklogs/counts?offset=<days>  (default: 14)`);
+  console.log(`  GET  http://localhost:${PORT}/config`);
 });

--- a/packages/web/src/components/ChatPanel.jsx
+++ b/packages/web/src/components/ChatPanel.jsx
@@ -1,6 +1,71 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { LMStudioClient, Chat } from "lmstudio-js";
+import { LM_STUDIO_TOOL_DEFINITIONS, executeHindsightTool } from '../lib/hindsightTools'
 import './ChatPanel.css'
+
+const DEFAULT_LM_STUDIO_URL = 'http://127.0.0.1:1234'
+const DEFAULT_HINDSIGHT_API_URL = 'http://localhost:3000'
+const DEFAULT_CHAT_MODEL = 'qwen/qwen3-vl-4b'
+const MAX_TOOL_CALLING_ROUNDS = 6
+
+function normalizeLmStudioBaseUrl(rawUrl) {
+  const trimmed = rawUrl.trim().replace(/\/+$/, '')
+  if (trimmed.startsWith('ws://')) return `http://${trimmed.slice(5)}`
+  if (trimmed.startsWith('wss://')) return `https://${trimmed.slice(6)}`
+  return trimmed
+}
+
+function parseJsonSafe(value, fallback = {}) {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return fallback
+  }
+}
+
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function fetchConfiguredModel(hindsightApiUrl) {
+  const response = await fetch(`${hindsightApiUrl}/config`)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch config (${response.status})`)
+  }
+
+  const body = await response.json()
+  return typeof body?.visionModel === 'string' && body.visionModel.trim()
+    ? body.visionModel.trim()
+    : null
+}
+
+async function createChatCompletion({ baseUrl, apiToken, model, messages }) {
+  const headers = {
+    'Content-Type': 'application/json'
+  }
+  if (apiToken) {
+    headers.Authorization = `Bearer ${apiToken}`
+  }
+
+  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model,
+      messages,
+      tools: LM_STUDIO_TOOL_DEFINITIONS,
+      tool_choice: 'auto',
+      temperature: 0
+    })
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    const details = body ? `: ${body}` : ''
+    throw new Error(`LM Studio API error ${response.status}${details}`)
+  }
+
+  return response.json()
+}
 
 function ChatPanel() {
   const [messages, setMessages] = useState([])
@@ -9,9 +74,11 @@ function ChatPanel() {
   const [error, setError] = useState(null)
   const messagesEndRef = useRef(null)
   const inputRef = useRef(null)
-  const clientRef = useRef(null)
-  const toolsSessionRef = useRef(null)
-  const chatRef = useRef(Chat.empty())
+  const conversationRef = useRef([])
+  const lmStudioBaseUrlRef = useRef(DEFAULT_LM_STUDIO_URL)
+  const hindsightApiUrlRef = useRef(DEFAULT_HINDSIGHT_API_URL)
+  const apiTokenRef = useRef('')
+  const modelRef = useRef(DEFAULT_CHAT_MODEL)
 
   const examplePrompts = [
     'Summarize my recent activity',
@@ -20,43 +87,30 @@ function ChatPanel() {
     'What should I focus on next?'
   ]
 
-  // Initialize LM Studio client and plugin tools session
+  // Initialize connection settings and load chat model from API config (.env -> VISION_MODEL)
   useEffect(() => {
-    const initClient = async () => {
-      try {
-        const apiToken = import.meta.env.VITE_LM_API_TOKEN
-        if (!apiToken) {
-          console.warn('LM_API_TOKEN not found in environment variables. LM Studio connection may fail.')
-        }
-        const lmStudioUrl = import.meta.env.VITE_LM_STUDIO_URL || 'ws://127.0.0.1:1234'
-        const hindsightApiUrl = import.meta.env.VITE_HINDSIGHT_API_URL || 'http://localhost:3000'
-        const client = new LMStudioClient({
-          baseUrl: lmStudioUrl,
-          apiToken: apiToken
-        })
-        clientRef.current = client
+    let disposed = false
+    lmStudioBaseUrlRef.current = normalizeLmStudioBaseUrl(import.meta.env.VITE_LM_STUDIO_URL || DEFAULT_LM_STUDIO_URL)
+    hindsightApiUrlRef.current = (import.meta.env.VITE_HINDSIGHT_API_URL || DEFAULT_HINDSIGHT_API_URL).trim().replace(/\/+$/, '')
+    apiTokenRef.current = (import.meta.env.VITE_LM_API_TOKEN || '').trim()
+    modelRef.current = (import.meta.env.VITE_LM_CHAT_MODEL || DEFAULT_CHAT_MODEL).trim()
 
-        // Set up remote tools session for the hindsight plugin
-        const toolsSession = await client.plugins.pluginTools("nicholsonjf/hindsight", {
-          pluginConfig: {
-            fields: [
-              { key: "hindsightApiUrl", value: hindsightApiUrl }
-            ]
-          }
-        })
-        toolsSessionRef.current = toolsSession
-        console.log('Hindsight plugin tools session initialized')
-      } catch (err) {
-        console.error('Failed to initialize LM Studio client or plugin tools:', err)
+    const initModel = async () => {
+      try {
+        const configuredModel = await fetchConfiguredModel(hindsightApiUrlRef.current)
+        if (!disposed && configuredModel) {
+          modelRef.current = configuredModel
+          console.info(`Using configured VISION_MODEL from API: ${configuredModel}`)
+        }
+      } catch (configError) {
+        console.warn('Could not load configured VISION_MODEL from API; using chat fallback model:', configError)
       }
     }
-    initClient()
 
-    // Cleanup tools session on unmount
+    void initModel()
+
     return () => {
-      if (toolsSessionRef.current && toolsSessionRef.current[Symbol.dispose]) {
-        toolsSessionRef.current[Symbol.dispose]()
-      }
+      disposed = true
     }
   }, [])
 
@@ -71,7 +125,7 @@ function ChatPanel() {
 
   // Handle sending message
   const sendMessage = async () => {
-    if (!input.trim() || !clientRef.current || loading) return
+    if (!input.trim() || loading) return
 
     const userMessage = input.trim()
     setInput('')
@@ -79,68 +133,73 @@ function ChatPanel() {
     setLoading(true)
     setError(null)
 
-    // Append user message to chat history
-    chatRef.current.append("user", userMessage)
-
-    // Add placeholder for streaming assistant response
+    const chatMessages = [...conversationRef.current, { role: 'user', content: userMessage }]
     let assistantContent = ''
     setMessages(prev => [...prev, { role: 'assistant', content: '' }])
 
     try {
-      // Get list of loaded models
-      const models = await clientRef.current.llm.listLoaded()
-
-      if (models.length === 0) {
-        throw new Error('No models loaded in LM Studio')
-      }
-
-      // Use the first loaded model
-      const model = models[0]
-
-      // Get plugin tools (may be empty if plugin not available)
-      const tools = toolsSessionRef.current?.tools || []
-
-      // Use .act() method with plugin tools for agentic behavior
-      await model.act(chatRef.current, tools, {
-        onMessage: (message) => {
-          // Append message to chat history to maintain conversation context
-          chatRef.current.append(message)
-        },
-        onPredictionFragment: (fragment) => {
-          // Skip structural fragments (formatting tokens)
-          if (fragment.isStructural) return
-          // Accumulate content and update display
-          assistantContent += fragment.content
-          setMessages(prev => {
-            const updated = [...prev]
-            updated[updated.length - 1] = { role: 'assistant', content: assistantContent }
-            return updated
-          })
-        },
-        onToolCallRequestEnd: (_roundIndex, _callId, info) => {
-          console.log(`Tool called: ${info.toolCallRequest.name}`, info.toolCallRequest.arguments)
-        },
-        onToolCallResult: (_roundIndex, _callId, result) => {
-          console.log('Tool result:', result)
-        }
-      })
-
-      // If no content was streamed, update with final message
-      if (!assistantContent) {
-        setMessages(prev => {
-          const updated = [...prev]
-          updated[updated.length - 1] = { role: 'assistant', content: 'I processed your request but have no text response.' }
-          return updated
+      for (let round = 0; round < MAX_TOOL_CALLING_ROUNDS; round += 1) {
+        const completion = await createChatCompletion({
+          baseUrl: lmStudioBaseUrlRef.current,
+          apiToken: apiTokenRef.current,
+          model: modelRef.current,
+          messages: chatMessages
         })
+
+        const choice = completion?.choices?.[0]
+        const assistantMessage = choice?.message
+        if (!assistantMessage) {
+          throw new Error('LM Studio returned an empty response')
+        }
+
+        chatMessages.push({
+          role: 'assistant',
+          content: assistantMessage.content ?? '',
+          tool_calls: assistantMessage.tool_calls ?? []
+        })
+
+        const toolCalls = Array.isArray(assistantMessage.tool_calls) ? assistantMessage.tool_calls : []
+        if (choice.finish_reason === 'tool_calls' && toolCalls.length > 0) {
+          for (const toolCall of toolCalls) {
+            const toolName = toolCall?.function?.name
+            const toolArgs = parseJsonSafe(toolCall?.function?.arguments ?? '{}', {})
+            const toolResult = await executeHindsightTool(toolName, toolArgs, hindsightApiUrlRef.current)
+            console.log(`Tool called: ${toolName}`, toolArgs)
+            console.log('Tool result:', toolResult)
+            chatMessages.push({
+              role: 'tool',
+              tool_call_id: toolCall.id,
+              name: toolName,
+              content: JSON.stringify(toolResult)
+            })
+          }
+          continue
+        }
+
+        assistantContent = (assistantMessage.content || '').trim()
+        break
       }
+
+      if (!assistantContent) {
+        assistantContent = 'I processed your request but have no text response.'
+      }
+
+      conversationRef.current = chatMessages
+      setMessages(prev => {
+        const updated = [...prev]
+        updated[updated.length - 1] = { role: 'assistant', content: assistantContent }
+        return updated
+      })
     } catch (err) {
-      console.error('LM Studio error:', err)
-      setError('Failed to connect to LM Studio. Please ensure LM Studio is running at http://127.0.0.1:1234 with a model loaded.')
+      console.error('LM Studio chat error:', err)
+      const errorMessage = toErrorMessage(err)
+      const configuredModel = modelRef.current
+      setError(`Chat failed: ${errorMessage}`)
       setMessages(prev => {
         const updated = [...prev]
         updated[updated.length - 1] = {
           role: 'assistant',
-          content: 'Sorry, I couldn\'t connect to LM Studio. Please check that it\'s running and a model is loaded.'
+          content: `Sorry, chat failed. Ensure LM Studio is running at ${lmStudioBaseUrlRef.current} and model "${configuredModel}" is loaded.`
         }
         return updated
       })

--- a/packages/web/src/lib/hindsightTools.js
+++ b/packages/web/src/lib/hindsightTools.js
@@ -1,0 +1,145 @@
+const DEFAULT_OFFSET_DAYS = 14
+const MIN_OFFSET_DAYS = 1
+const MAX_OFFSET_DAYS = 365
+
+export const LM_STUDIO_TOOL_DEFINITIONS = [
+  {
+    type: 'function',
+    function: {
+      name: 'available_hindsight_logs',
+      description: 'Returns counts of available Hindsight worklog entries by day for a lookback window.',
+      parameters: {
+        type: 'object',
+        properties: {
+          offset: {
+            type: 'integer',
+            minimum: MIN_OFFSET_DAYS,
+            maximum: MAX_OFFSET_DAYS,
+            description: `Number of days to look back (default: ${DEFAULT_OFFSET_DAYS})`
+          }
+        }
+      }
+    }
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_hindsight_logs',
+      description: 'Returns Hindsight worklog entries for a date range.',
+      parameters: {
+        type: 'object',
+        properties: {
+          start: {
+            type: 'string',
+            description: 'Start of the date range in ISO 8601 UTC format (YYYY-MM-DDTHH:MM:SSZ)'
+          },
+          end: {
+            type: 'string',
+            description: 'End of the date range in ISO 8601 UTC format (YYYY-MM-DDTHH:MM:SSZ)'
+          }
+        },
+        required: ['start', 'end']
+      }
+    }
+  }
+]
+
+function clampOffset(offset) {
+  const parsed = Number.parseInt(String(offset ?? DEFAULT_OFFSET_DAYS), 10)
+  if (Number.isNaN(parsed)) {
+    return DEFAULT_OFFSET_DAYS
+  }
+  return Math.min(MAX_OFFSET_DAYS, Math.max(MIN_OFFSET_DAYS, parsed))
+}
+
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url)
+  const body = await response.text()
+
+  if (!response.ok) {
+    const suffix = body ? `: ${body}` : ''
+    throw new Error(`HTTP ${response.status}${suffix}`)
+  }
+
+  if (!body) return null
+  return JSON.parse(body)
+}
+
+function toLocalDayRange(startIsoString, endIsoString) {
+  const startDate = new Date(startIsoString)
+  const endDate = new Date(endIsoString)
+
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+    throw new Error('Invalid start/end date format. Expected ISO 8601 UTC strings.')
+  }
+
+  const localStart = new Date(
+    startDate.getUTCFullYear(),
+    startDate.getUTCMonth(),
+    startDate.getUTCDate(),
+    0, 0, 0, 0
+  )
+
+  const localEnd = new Date(
+    endDate.getUTCFullYear(),
+    endDate.getUTCMonth(),
+    endDate.getUTCDate(),
+    23, 59, 59, 999
+  )
+
+  return {
+    start: Math.floor(localStart.getTime() / 1000),
+    end: Math.floor(localEnd.getTime() / 1000)
+  }
+}
+
+async function executeAvailableHindsightLogs(args, hindsightApiUrl) {
+  const offset = clampOffset(args?.offset)
+  try {
+    const query = new URLSearchParams({ offset: String(offset) })
+    const data = await fetchJson(`${hindsightApiUrl}/worklogs/counts?${query}`)
+    return { success: true, data }
+  } catch (error) {
+    return { success: false, error: toErrorMessage(error) }
+  }
+}
+
+async function executeGetHindsightLogs(args, hindsightApiUrl) {
+  const start = args?.start
+  const end = args?.end
+
+  if (typeof start !== 'string' || typeof end !== 'string') {
+    return {
+      success: false,
+      error: 'start and end must be provided as ISO 8601 UTC strings'
+    }
+  }
+
+  try {
+    const range = toLocalDayRange(start, end)
+    const query = new URLSearchParams({
+      start: String(range.start),
+      end: String(range.end)
+    })
+    const data = await fetchJson(`${hindsightApiUrl}/worklogs?${query}`)
+    return { success: true, data }
+  } catch (error) {
+    return { success: false, error: toErrorMessage(error) }
+  }
+}
+
+export async function executeHindsightTool(name, args, hindsightApiUrl) {
+  if (name === 'available_hindsight_logs') {
+    return executeAvailableHindsightLogs(args, hindsightApiUrl)
+  }
+
+  if (name === 'get_hindsight_logs') {
+    return executeGetHindsightLogs(args, hindsightApiUrl)
+  }
+
+  return { success: false, error: `Unknown tool: ${name}` }
+}


### PR DESCRIPTION
Closes #1 .

Replace the web chat SDK/pluginTools flow with an HTTP-based LM Studio `/v1/chat/completions` tool-calling loop so chat no longer depends on LM Studio plugin-use permissions.

Adjust startup script order so plugin dev server runs before web UI.

<img width="1824" height="1095" alt="Screenshot 2026-02-26 at 20 28 04" src="https://github.com/user-attachments/assets/e71efa45-9ebb-4adf-9495-8397833d3331" />
